### PR TITLE
Fix /tmp permissions for codespaces

### DIFF
--- a/src/Dockerfile
+++ b/src/Dockerfile
@@ -38,7 +38,8 @@ RUN apt -y install --no-install-recommends \
     dialog \
     locales \
     man-db \
-    bash-completion
+    bash-completion \
+    acl
 
 # create at least locae for en_US.UTF-8
 RUN echo "en_US.UTF-8 UTF-8" >> /etc/locale.gen && locale-gen

--- a/src/docker-entrypoint.sh
+++ b/src/docker-entrypoint.sh
@@ -1,5 +1,13 @@
 #!/bin/bash
 
+# github codespaces fixes
+if [ "${CODESPACES}" = true ]; then
+  # vscode codespaces set default permissions on /tmp. These will
+  # produce invalid permissions on files built with nix. This fix
+  # removes default permissions set on /tmp
+  sudo setfacl --remove-default /tmp
+fi
+
 if [ ! -z "${PRELOAD_EXTENSIONS}" ]; then
   ext-preloader &
 fi


### PR DESCRIPTION
Vscode codespaces set default permissions on /tmp. These will produce invalid permissions on files built with nix. This fix removes default permissions set on /tmp

Note: To test this pull request fork this repo and open codespaces with devcontainer in `.devcontainer/codespaces/devcontainer.json` like mentioned here: https://github.com/xtruder/nix-devcontainer/pull/13#issuecomment-1231560501

Fixes #12, #9
Closes #13

@dsyer @dzmitry-lahoda